### PR TITLE
feat: format JSON output to stabilize its output

### DIFF
--- a/internal/gen/proto/einride/serviceconfig/example/v1/example_grpc_service_config.pb.go
+++ b/internal/gen/proto/einride/serviceconfig/example/v1/example_grpc_service_config.pb.go
@@ -4,18 +4,18 @@ package examplev1
 // DefaultServiceConfig is the default service config for all services in the package.
 // Source: einride/serviceconfig/example/v1/default_service_config.proto.
 const DefaultServiceConfig = `{
-  "methodConfig":  [
+  "methodConfig": [
     {
-      "name":  [
+      "name": [
         {}
       ],
-      "timeout":  "10s",
-      "retryPolicy":  {
-        "maxAttempts":  5,
-        "initialBackoff":  "0.200s",
-        "maxBackoff":  "60s",
-        "backoffMultiplier":  2,
-        "retryableStatusCodes":  [
+      "timeout": "10s",
+      "retryPolicy": {
+        "maxAttempts": 5,
+        "initialBackoff": "0.200s",
+        "maxBackoff": "60s",
+        "backoffMultiplier": 2,
+        "retryableStatusCodes": [
           "UNAVAILABLE",
           "UNKNOWN"
         ]


### PR DESCRIPTION
protojson doesn't guarantee stable JSON output, and deliberately
introduce minor differences in output to prevent the illusion of this,
see [1].

As this tool generates code, we'd like to keep the output as stable as
possible, use the advice in [1] and [2] (at the end) and run the
generated JSON through a formatter before including it in the generated
code. This also changes from using the error ignoring Format() function
to Marshal().

[1]: https://developers.google.com/protocol-buffers/docs/reference/go/faq#unstable-json
[2]: https://github.com/golang/protobuf/issues/1121#issuecomment-627554847