### PR TITLE
feat: allow optional keyword

### DIFF
--- a/cmd/protoc-gen-go-grpc-service-config/main.go
+++ b/cmd/protoc-gen-go-grpc-service-config/main.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/pluginpb"
 )
 
 const docURL = "https://github.com/grpc/grpc/blob/master/doc/service_config.md"
@@ -31,6 +32,7 @@ func main() {
 	protogen.Options{
 		ParamFunc: flags.Set,
 	}.Run(func(gen *protogen.Plugin) error {
+		gen.SupportedFeatures = uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)
 		p, err := newPlugin(gen, *path)
 		if err != nil {
 			return err


### PR DESCRIPTION
Adding support for `optional` keyword.
This plugin doesn't make use of `optional` fields, so this change just silences the warning when generating Go code from protos.